### PR TITLE
Graph-Klasse mit Kontruktor

### DIFF
--- a/graphtool/CMakeLists.txt
+++ b/graphtool/CMakeLists.txt
@@ -3,5 +3,5 @@ project(graphtool)
 
 set(CMAKE_CXX_STANDARD 14)
 
-set(SOURCE_FILES main.cpp)
+set(SOURCE_FILES main.cpp Graph.cpp)
 add_executable(graphtool ${SOURCE_FILES})

--- a/graphtool/Graph.cpp
+++ b/graphtool/Graph.cpp
@@ -12,7 +12,7 @@ Graph::Graph(std::vector<std::vector<int>> adjacencyMatrix) {
     };
 }
 
-boolean Graph::isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const {
+bool Graph::isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const {
     int rows = (int) adjacencyMatrix.size();
     int cols = 0;
     for (std::vector<int> row : adjacencyMatrix) {

--- a/graphtool/Graph.cpp
+++ b/graphtool/Graph.cpp
@@ -1,0 +1,29 @@
+
+#include <vector>
+#include <stdexcept>
+#include "Graph.h"
+
+Graph::Graph(std::vector<std::vector<int>> adjacencyMatrix) {
+
+    if (isSymmetricMatrix(adjacencyMatrix)) {
+        this->adjacencyMatrix = adjacencyMatrix;
+    } else {
+        throw std::invalid_argument("adjacency matix must be symmetrical");
+    };
+}
+
+boolean Graph::isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const {
+    int rows = (int) adjacencyMatrix.size();
+    int cols = 0;
+    for (std::vector<int> row : adjacencyMatrix) {
+        if (row.size() > cols) {
+            cols = (int) row.size();
+        }
+    }
+
+    return rows == cols;
+}
+
+const std::vector<std::vector<int>> &Graph::getAdjacencyMatrix() const {
+    return adjacencyMatrix;
+}

--- a/graphtool/Graph.cpp
+++ b/graphtool/Graph.cpp
@@ -3,19 +3,19 @@
 #include <stdexcept>
 #include "Graph.h"
 
-Graph::Graph(std::vector<std::vector<int>> adjacencyMatrix) {
+Graph::Graph(vector<vector<int>> adjacencyMatrix) {
 
     if (isSymmetricMatrix(adjacencyMatrix)) {
         this->adjacencyMatrix = adjacencyMatrix;
     } else {
-        throw std::invalid_argument("adjacency matix must be symmetrical");
+        throw invalid_argument("adjacency matrix has to be symmetrical");
     };
 }
 
-bool Graph::isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const {
+bool Graph::isSymmetricMatrix(const vector<vector<int>> &adjacencyMatrix) const {
     int rows = (int) adjacencyMatrix.size();
     int cols = 0;
-    for (std::vector<int> row : adjacencyMatrix) {
+    for (vector<int> row : adjacencyMatrix) {
         if (row.size() > cols) {
             cols = (int) row.size();
         }
@@ -24,6 +24,14 @@ bool Graph::isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatr
     return rows == cols;
 }
 
-const std::vector<std::vector<int>> &Graph::getAdjacencyMatrix() const {
+const vector<vector<int>> &Graph::getAdjacencyMatrix() const {
     return adjacencyMatrix;
+}
+
+/**
+ * Detect the number of nodes of the given graph.
+ * @return number of nodes.
+ */
+int Graph::getNumberOfNodes() const {
+    return this->adjacencyMatrix.size();
 }

--- a/graphtool/Graph.h
+++ b/graphtool/Graph.h
@@ -2,20 +2,28 @@
 
 #include <vector>
 
+using namespace std;
+
 /**
  * Represents a graph. Has certain verifiable properties.
  */
 class Graph {
 
 private:
-    std::vector<std::vector<int>> adjacencyMatrix;
+    vector<vector<int>> adjacencyMatrix;
 
 public:
-    Graph(std::vector<std::vector<int>> adjacencyMatrix);
+    Graph(vector<vector<int>> adjacencyMatrix);
 
-    bool isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const;
+    bool isSymmetricMatrix(const vector<vector<int>> &adjacencyMatrix) const;
 
-    const std::vector<std::vector<int>> &getAdjacencyMatrix() const;
+    /**
+     * Detect the number of nodes of the given graph.
+     * @return number of nodes.
+     */
+    int getNumberOfNodes() const;
+
+    const vector<vector<int>> &getAdjacencyMatrix() const;
 };
 
 

--- a/graphtool/Graph.h
+++ b/graphtool/Graph.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vector>
-#include <jmorecfg.h>
 
 /**
  * Represents a graph. Has certain verifiable properties.
@@ -14,7 +13,7 @@ private:
 public:
     Graph(std::vector<std::vector<int>> adjacencyMatrix);
 
-    boolean isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const;
+    bool isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const;
 
     const std::vector<std::vector<int>> &getAdjacencyMatrix() const;
 };

--- a/graphtool/Graph.h
+++ b/graphtool/Graph.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+#include <jmorecfg.h>
+
+/**
+ * Represents a graph. Has certain verifiable properties.
+ */
+class Graph {
+
+private:
+    std::vector<std::vector<int>> adjacencyMatrix;
+
+public:
+    Graph(std::vector<std::vector<int>> adjacencyMatrix);
+
+    boolean isSymmetricMatrix(const std::vector<std::vector<int>> &adjacencyMatrix) const;
+
+    const std::vector<std::vector<int>> &getAdjacencyMatrix() const;
+};
+
+

--- a/graphtool/main.cpp
+++ b/graphtool/main.cpp
@@ -2,10 +2,12 @@
 #include <vector>
 #include "Graph.h"
 
+using namespace std;
+
 int main() {
 
     // Beispiel aus https://de.wikipedia.org/wiki/Adjazenzmatrix oben
-    std::vector<std::vector<int>> am1 = {
+    vector<vector<int>> am1 = {
             {0, 1, 0, 0},
             {1, 0, 1, 1},
             {0, 1, 0, 0},
@@ -14,7 +16,11 @@ int main() {
 
     Graph *g = new Graph(am1);
 
-    std::cout << (g->getAdjacencyMatrix().at(0).at(1) == 1 ? "Zeile 1, Spalte 2 ist 1"
-                                                           : "Zeile 1, Spalte 2 ist **NICHT** 1") << std::endl;
+    cout << (g->getAdjacencyMatrix().at(0).at(1) == 1 ? "Zeile 1, Spalte 2 ist 1"
+                                                           : "Zeile 1, Spalte 2 ist **NICHT** 1") << endl;
+
+    // Number of  nodes
+    cout << "Number of nodes: " << g->getNumberOfNodes() << endl;
+
     return 0;
 }

--- a/graphtool/main.cpp
+++ b/graphtool/main.cpp
@@ -1,6 +1,20 @@
 #include <iostream>
+#include <vector>
+#include "Graph.h"
 
 int main() {
-    std::cout << "Hello, World!" << std::endl;
+
+    // Beispiel aus https://de.wikipedia.org/wiki/Adjazenzmatrix oben
+    std::vector<std::vector<int>> am1 = {
+            {0, 1, 0, 0},
+            {1, 0, 1, 1},
+            {0, 1, 0, 0},
+            {0, 1, 0, 0},
+    };
+
+    Graph *g = new Graph(am1);
+
+    std::cout << (g->getAdjacencyMatrix().at(0).at(1) == 1 ? "Zeile 1, Spalte 2 ist 1"
+                                                           : "Zeile 1, Spalte 2 ist **NICHT** 1") << std::endl;
     return 0;
 }


### PR DESCRIPTION
- Wie besprochen sind einmal erstellte Graphen nicht erweiterbar (weitere Knoten oder Kanten)
- Adjazenzmatrizen müssen symmetrisch sein (wg. Anzahl Knoten in beiden Ebenen)